### PR TITLE
Cannot run in Development mode unless SSL is setup

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   before_filter :load_settings
   before_filter :load_talks
 
-  force_ssl
+  force_ssl if Rails.env.production?
 
   def load_settings
     Cfp::Config.load_from_persistance if Rails.env.development?


### PR DESCRIPTION
Adding a check to see if Rails is running in production to allow running Rails in development mode to be non-ssl.